### PR TITLE
fix: set numpy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ grpcio-tools<=1.60.1
 protobuf<=4.25.3
 scikit-learn<=1.5.0
 interopt<=0.2.1
+numpy==1.26.4


### PR DESCRIPTION
The current version of this project is broken since it installs numpy > 2.0.0. This will raise an exception when trying to `import catbench`

This pr fixes it by setting the numpy version to 1.26.4